### PR TITLE
$object->client is deprecated since 4.0

### DIFF
--- a/core/triggers/interface_98_modRemise_Remise.class.php
+++ b/core/triggers/interface_98_modRemise_Remise.class.php
@@ -143,11 +143,12 @@ class InterfaceRemise
 			    dol_include_once('/product/class/product.class.php','Product');
 				$total = TRemise::getTotal($object);
                 $remise_used_montant = TRemise::getRemise($PDOdb, 'AMOUNT', $total, '', 0, $object->socid);
+				$thirdparty = isset($object->thirdparty) ? $object->thirdparty : $object->client;
 				
                 $remise_used_weight = 0;
                 if($conf->global->REMISE_USE_WEIGHT) {
                 	$total_weight = TRemise::getTotalWeight($object);
-					$remise_used_weight = TRemise::getRemise($PDOdb, 'WEIGHT', $total_weight, $object->thirdparty->zip);
+					$remise_used_weight = TRemise::getRemise($PDOdb, 'WEIGHT', $total_weight, $thirdparty->zip);
 					
 				}
                
@@ -160,7 +161,7 @@ class InterfaceRemise
 				$object->brouillon = 1;
 				
 				//$used_tva = ($object->thirdparty->tva_assuj == 1) ? $p->tva_tx : 0;
-				$used_tva = get_default_tva($mysoc, $object->thirdparty, $p->id);
+				$used_tva = get_default_tva($mysoc, $thirdparty, $p->id);
 				
 				if(empty($conf->global->REMISE_USE_THIRDPARTY_DISCOUNT)) {
 

--- a/core/triggers/interface_98_modRemise_Remise.class.php
+++ b/core/triggers/interface_98_modRemise_Remise.class.php
@@ -118,7 +118,7 @@ class InterfaceRemise
         // Users
         if ($action == 'ORDER_VALIDATE' || $action == 'PROPAL_VALIDATE' || $action == 'BILL_VALIDATE') {
         	
-			global $db,$conf;
+			global $db,$conf,$mysoc;
 
 			$langs->load('remise@remise');
 			
@@ -147,7 +147,7 @@ class InterfaceRemise
                 $remise_used_weight = 0;
                 if($conf->global->REMISE_USE_WEIGHT) {
                 	$total_weight = TRemise::getTotalWeight($object);
-					$remise_used_weight = TRemise::getRemise($PDOdb, 'WEIGHT', $total_weight, $object->client->zip);
+					$remise_used_weight = TRemise::getRemise($PDOdb, 'WEIGHT', $total_weight, $object->thirdparty->zip);
 					
 				}
                
@@ -159,7 +159,8 @@ class InterfaceRemise
 				$object->statut = 0;
 				$object->brouillon = 1;
 				
-				$used_tva = ($object->client->tva_assuj == 1) ? $p->tva_tx : 0;
+				//$used_tva = ($object->thirdparty->tva_assuj == 1) ? $p->tva_tx : 0;
+				$used_tva = get_default_tva($mysoc, $object->thirdparty, $p->id);
 				
 				if(empty($conf->global->REMISE_USE_THIRDPARTY_DISCOUNT)) {
 


### PR DESCRIPTION
replaced by $object->thirdparty
+ TVA utilisée dans la ligne de remise n'a rien à voir avec tva_assuj du client. Pourquoi ce test ?